### PR TITLE
feat: loading states e metadata Open Graph

### DIFF
--- a/src/app/(app)/calendario/loading.tsx
+++ b/src/app/(app)/calendario/loading.tsx
@@ -1,0 +1,10 @@
+export default function CalendarioLoading() {
+  return (
+    <div className="flex flex-col gap-3 p-4 animate-pulse">
+      <div className="h-10 w-48 rounded-lg bg-surface-3" />
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="h-20 rounded-xl bg-surface-3" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,14 @@
+export default function DashboardLoading() {
+  return (
+    <div className="flex flex-col gap-4 p-4 animate-pulse">
+      <div className="h-24 rounded-2xl bg-surface-3" />
+      <div className="grid grid-cols-4 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-16 rounded-xl bg-surface-3" />
+        ))}
+      </div>
+      <div className="h-40 rounded-2xl bg-surface-3" />
+      <div className="h-40 rounded-2xl bg-surface-3" />
+    </div>
+  );
+}

--- a/src/app/(app)/grupos/loading.tsx
+++ b/src/app/(app)/grupos/loading.tsx
@@ -1,0 +1,14 @@
+export default function GruposLoading() {
+  return (
+    <div className="flex flex-col gap-4 p-4 animate-pulse">
+      <div className="flex gap-2">
+        {["A", "B", "C", "D"].map((g) => (
+          <div key={g} className="h-9 w-12 rounded-lg bg-surface-3" />
+        ))}
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-14 rounded-xl bg-surface-3" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/ranking/loading.tsx
+++ b/src/app/(app)/ranking/loading.tsx
@@ -1,0 +1,10 @@
+export default function RankingLoading() {
+  return (
+    <div className="flex flex-col gap-3 p-4 animate-pulse">
+      <div className="h-10 w-40 rounded-lg bg-surface-3" />
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="h-16 rounded-xl bg-surface-3" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,24 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "QG Open 2026",
+  title: {
+    default: "QG Open 2026",
+    template: "%s · QG Open 2026",
+  },
   description: "Campeonato de Tênis QG Open 2026 — Compita. Supere. Seja Lendário.",
   manifest: "/manifest.json",
+  openGraph: {
+    title: "QG Open 2026",
+    description: "Campeonato de Tênis QG Open 2026 — Compita. Supere. Seja Lendário.",
+    type: "website",
+    locale: "pt_BR",
+    siteName: "QG Open 2026",
+  },
+  twitter: {
+    card: "summary",
+    title: "QG Open 2026",
+    description: "Campeonato de Tênis QG Open 2026 — Compita. Supere. Seja Lendário.",
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## O que foi feito

### Loading States (UX)
Adicionados arquivos `loading.tsx` com skeleton animado para as 4 páginas principais:
- `/dashboard` — cards de estatísticas + próxima partida
- `/ranking` — lista de jogadores
- `/grupos` — tabs A/B/C/D + tabela
- `/calendario` — lista de partidas agendadas

O Next.js usa esses arquivos automaticamente enquanto a página carrega dados do Supabase, eliminando telas em branco.

### Metadata Open Graph
- Título dinâmico por página via `template: "%s · QG Open 2026"`
- Open Graph completo (título, descrição, locale pt_BR, siteName)
- Twitter Card para compartilhamento em redes sociais

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq9ThXK9QMXGWTk6pXbRmY)_