### PR TITLE
feat: metadata de título dinâmico por página

### DIFF
--- a/src/app/(app)/calendario/page.tsx
+++ b/src/app/(app)/calendario/page.tsx
@@ -1,6 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getAllMatches } from "@/lib/queries/matches";
+
+export const metadata: Metadata = { title: "Calendário" };
 import { getAllPlayers, getPlayerByUserId } from "@/lib/queries/players";
 import { CalendarioClient } from "./CalendarioClient";
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,5 +1,8 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = { title: "Dashboard" };
 import { getPlayerByUserId } from "@/lib/queries/players";
 import { getMatchesByPlayer, getAllMatches } from "@/lib/queries/matches";
 import { getAllPlayers } from "@/lib/queries/players";

--- a/src/app/(app)/grupos/page.tsx
+++ b/src/app/(app)/grupos/page.tsx
@@ -1,4 +1,7 @@
+import type { Metadata } from "next";
 import { getAllPlayers } from "@/lib/queries/players";
+
+export const metadata: Metadata = { title: "Grupos" };
 import { getAllMatches } from "@/lib/queries/matches";
 import { computeAllStandings } from "@/lib/queries/standings";
 import { GruposClient } from "./GruposClient";

--- a/src/app/(app)/perfil/page.tsx
+++ b/src/app/(app)/perfil/page.tsx
@@ -1,6 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getPlayerByUserId, getAllPlayers } from "@/lib/queries/players";
+
+export const metadata: Metadata = { title: "Perfil" };
 import { getMatchesByPlayer, getAllMatches } from "@/lib/queries/matches";
 import { computeAllStandings } from "@/lib/queries/standings";
 import { PerfilClient } from "./PerfilClient";

--- a/src/app/(app)/ranking/page.tsx
+++ b/src/app/(app)/ranking/page.tsx
@@ -1,5 +1,8 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = { title: "Ranking" };
 import { getPlayerByUserId, getAllPlayers } from "@/lib/queries/players";
 import { getAllMatches } from "@/lib/queries/matches";
 import { computeAllStandings, computeGlobalRanking } from "@/lib/queries/standings";


### PR DESCRIPTION
## O que foi feito

Cada rota principal agora exporta `metadata` com título próprio.

O template `"%s · QG Open 2026"` definido no layout raiz compõe automaticamente:
- `Dashboard · QG Open 2026`
- `Ranking · QG Open 2026`
- `Grupos · QG Open 2026`
- `Calendário · QG Open 2026`
- `Perfil · QG Open 2026`

Melhora o histórico do navegador, bookmarks e SEO.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq9ThXK9QMXGWTk6pXbRmY)_