### PR TITLE
feat: registro de resultado integrado ao calendário de partidas

### DIFF
--- a/src/app/(app)/calendario/CalendarioClient.tsx
+++ b/src/app/(app)/calendario/CalendarioClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { MatchResultPanel } from "@/components/panels/MatchResultPanel";
 import { cn } from "@/utils/cn";
 import {
   format, startOfMonth, endOfMonth, eachDayOfInterval,
@@ -14,7 +15,7 @@ import {
 import { ptBR } from "date-fns/locale";
 import {
   ChevronLeft, ChevronRight, Plus, X, Search,
-  Clock, MapPin, Check, Loader2,
+  Clock, MapPin, Check, Loader2, ClipboardList,
 } from "lucide-react";
 import { scheduleMatchAction } from "@/lib/actions/scheduleMatch";
 import type { Match, Player } from "@/types";
@@ -65,14 +66,18 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [filter, setFilter]           = useState<FilterType>("todos");
 
-  const [showModal, setShowModal]           = useState(false);
-  const [opponent, setOpponent]             = useState<Player | null>(null);
-  const [opponentSearch, setOpponentSearch] = useState("");
-  const [scheduleTime, setScheduleTime]     = useState("10:00");
-  const [court, setCourt]                   = useState("");
-  const [saving, setSaving]                 = useState(false);
-  const [saveError, setSaveError]           = useState<string | null>(null);
-  const [saveSuccess, setSaveSuccess]       = useState(false);
+  // Schedule modal state
+  const [showScheduleModal, setShowScheduleModal] = useState(false);
+  const [opponent, setOpponent]                   = useState<Player | null>(null);
+  const [opponentSearch, setOpponentSearch]       = useState("");
+  const [scheduleTime, setScheduleTime]           = useState("10:00");
+  const [court, setCourt]                         = useState("");
+  const [saving, setSaving]                       = useState(false);
+  const [saveError, setSaveError]                 = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess]             = useState(false);
+
+  // Result modal state
+  const [resultMatch, setResultMatch] = useState<Match | null>(null);
 
   const calendarDays = useMemo(() => {
     const start = startOfWeek(startOfMonth(currentMonth), { weekStartsOn: 1 });
@@ -116,19 +121,19 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
     [opponents, opponentSearch]
   );
 
-  function openModal() {
+  function openScheduleModal() {
     setOpponent(null);
     setOpponentSearch("");
     setScheduleTime("10:00");
     setCourt("");
     setSaveError(null);
     setSaveSuccess(false);
-    setShowModal(true);
+    setShowScheduleModal(true);
   }
 
-  function closeModal() {
+  function closeScheduleModal() {
     if (saving) return;
-    setShowModal(false);
+    setShowScheduleModal(false);
   }
 
   async function handleSchedule() {
@@ -153,10 +158,19 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
 
     setSaveSuccess(true);
     setTimeout(() => {
-      setShowModal(false);
+      setShowScheduleModal(false);
       setSaveSuccess(false);
       router.refresh();
     }, 1200);
+  }
+
+  function isMyMatch(match: Match): boolean {
+    if (!currentPlayer) return false;
+    return match.player1_id === currentPlayer.id || match.player2_id === currentPlayer.id;
+  }
+
+  function canRegisterResult(match: Match): boolean {
+    return isMyMatch(match) && (match.status === "scheduled" || match.status === "pending_result");
   }
 
   const weekDays = ["Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"];
@@ -266,7 +280,7 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
               </p>
               {currentPlayer && (
                 <button
-                  onClick={openModal}
+                  onClick={openScheduleModal}
                   className="flex items-center gap-1 text-xs font-bold text-lime-500/80 bg-lime-500/10 hover:bg-lime-500/15 border border-lime-500/20 transition-colors px-3 py-1.5 rounded-full"
                 >
                   <Plus size={12} />
@@ -286,8 +300,9 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
               </div>
             ) : (
               filteredMatches.map((m) => {
-                const hasResult = m.status === "completed" || m.status === "wo";
-                const setsScore =
+                const hasResult    = m.status === "completed" || m.status === "wo";
+                const canRegister  = canRegisterResult(m);
+                const setsScore    =
                   hasResult && m.sets.length
                     ? `${m.sets.filter((s) => s.player1_games > s.player2_games).length}–${m.sets.filter((s) => s.player2_games > s.player1_games).length}`
                     : null;
@@ -295,7 +310,11 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                 return (
                   <div
                     key={m.id}
-                    className="flex items-center px-4 py-3.5 gap-3 border-b border-white/[0.03] last:border-0"
+                    className={cn(
+                      "flex items-center px-4 py-3.5 gap-3 border-b border-white/[0.03] last:border-0",
+                      canRegister && "cursor-pointer hover:bg-white/[0.03] active:bg-white/[0.05] transition-colors"
+                    )}
+                    onClick={() => canRegister && setResultMatch(m)}
                   >
                     <div className="text-right min-w-[36px]">
                       <span className="text-xs font-semibold text-white/35">
@@ -349,9 +368,15 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                         </div>
                       </div>
                     </div>
-                    <div className="shrink-0">
+                    <div className="shrink-0 flex items-center gap-2">
+                      {canRegister && (
+                        <span className="flex items-center gap-1 text-[10px] font-bold text-lime-500/70 bg-lime-500/10 border border-lime-500/20 px-2 py-1 rounded-lg">
+                          <ClipboardList size={10} />
+                          Registrar
+                        </span>
+                      )}
                       {m.status === "completed" && <Badge variant="victory" className="text-[9px]">Concluído</Badge>}
-                      {m.status === "scheduled" && <Badge variant="pending" className="text-[9px]">Pendente</Badge>}
+                      {m.status === "scheduled" && !canRegister && <Badge variant="pending" className="text-[9px]">Pendente</Badge>}
                       {m.status === "wo" && <Badge variant="wo" className="text-[9px]">WO</Badge>}
                     </div>
                   </div>
@@ -363,9 +388,9 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
       </div>
 
       {/* Schedule modal */}
-      {showModal && (
+      {showScheduleModal && (
         <div className="fixed inset-0 z-50 flex flex-col justify-end">
-          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={closeModal} />
+          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={closeScheduleModal} />
 
           <div className="relative bg-surface-2 border-t border-white/[0.08] rounded-t-3xl max-h-[90vh] flex flex-col animate-slide-up">
             <div className="flex justify-center pt-3 pb-1">
@@ -382,7 +407,7 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                 )}
               </div>
               <button
-                onClick={closeModal}
+                onClick={closeScheduleModal}
                 className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-3 text-white/40 hover:text-white hover:bg-surface-4 transition-colors"
               >
                 <X size={15} />
@@ -455,7 +480,7 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                         type="time"
                         value={scheduleTime}
                         onChange={(e) => setScheduleTime(e.target.value)}
-                        className="w-full pl-8 pr-3 py-2.5 text-sm bg-surface-3 border border-white/[0.07] text-white rounded-xl focus:outline-none focus:border-lime-500/40 transition-colors"
+                        className="w-full pl-8 pr-3 py-2.5 text-sm bg-surface-3 border border-white/[0.07] text-white rounded-xl focus:outline-none focus:border-lime-500/40 transition-colors [color-scheme:dark]"
                       />
                     </div>
                   </div>
@@ -503,6 +528,51 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                 </Button>
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Result registration modal */}
+      {resultMatch && (
+        <div className="fixed inset-0 z-50 flex flex-col justify-end">
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={() => setResultMatch(null)}
+          />
+
+          <div className="relative bg-surface-2 border-t border-white/[0.08] rounded-t-3xl max-h-[90vh] flex flex-col animate-slide-up">
+            <div className="flex justify-center pt-3 pb-1">
+              <div className="w-10 h-1 rounded-full bg-white/[0.12]" />
+            </div>
+
+            <div className="flex items-center justify-between px-5 py-3 border-b border-white/[0.06]">
+              <div>
+                <h2 className="font-display font-bold text-base text-white">Registrar Resultado</h2>
+                {resultMatch.scheduled_at && (
+                  <p className="text-[11px] text-white/30 capitalize mt-0.5">
+                    {format(new Date(resultMatch.scheduled_at), "EEEE, d 'de' MMMM · HH:mm", { locale: ptBR })}
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => setResultMatch(null)}
+                className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-3 text-white/40 hover:text-white hover:bg-surface-4 transition-colors"
+              >
+                <X size={15} />
+              </button>
+            </div>
+
+            <div className="overflow-y-auto flex-1">
+              <MatchResultPanel
+                match={resultMatch}
+                currentPlayerId={currentPlayer?.id ?? ""}
+                onClose={() => setResultMatch(null)}
+                onSuccess={() => {
+                  setResultMatch(null);
+                  router.refresh();
+                }}
+              />
+            </div>
           </div>
         </div>
       )}

--- a/src/components/panels/MatchResultPanel.tsx
+++ b/src/components/panels/MatchResultPanel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState } from "react";
+import { X, Plus, Minus, Check, Loader2, Trophy } from "lucide-react";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/utils/cn";
+import { submitMatchResultAction } from "@/lib/actions/submitMatchResult";
+import type { Match } from "@/types";
+
+interface SetScore {
+  p1: number;
+  p2: number;
+}
+
+function ScoreInput({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onChange(Math.max(0, value - 1))}
+        className="w-9 h-9 rounded-full bg-surface-3 border border-white/[0.08] flex items-center justify-center text-white/50 active:scale-95 transition-transform hover:bg-surface-4"
+      >
+        <Minus size={14} />
+      </button>
+      <span className="text-2xl font-display font-bold text-white/90 w-9 text-center tabular-nums">
+        {value}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(Math.min(7, value + 1))}
+        className="w-9 h-9 rounded-full bg-surface-3 border border-white/[0.08] flex items-center justify-center text-white/50 active:scale-95 transition-transform hover:bg-surface-4"
+      >
+        <Plus size={14} />
+      </button>
+    </div>
+  );
+}
+
+interface Props {
+  match: Match;
+  currentPlayerId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function MatchResultPanel({ match, currentPlayerId, onClose, onSuccess }: Props) {
+  const [sets, setSets] = useState<SetScore[]>([{ p1: 0, p2: 0 }]);
+  const [isWo, setIsWo] = useState(false);
+  const [woWinner, setWoWinner] = useState<"p1" | "p2" | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const isParticipant =
+    match.player1_id === currentPlayerId || match.player2_id === currentPlayerId;
+
+  function updateSet(idx: number, field: "p1" | "p2", value: number) {
+    setSets((prev) => prev.map((s, i) => (i === idx ? { ...s, [field]: value } : s)));
+  }
+
+  function computeWinner(): string | null {
+    if (isWo) {
+      if (!woWinner) return null;
+      return woWinner === "p1" ? match.player1_id : match.player2_id;
+    }
+    const p1Won = sets.filter((s) => s.p1 > s.p2).length;
+    const p2Won = sets.filter((s) => s.p2 > s.p1).length;
+    if (p1Won > p2Won) return match.player1_id;
+    if (p2Won > p1Won) return match.player2_id;
+    return null;
+  }
+
+  async function handleSubmit() {
+    const winnerId = computeWinner();
+    if (!winnerId) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const { error: err } = await submitMatchResultAction({
+      match_id: match.id,
+      winner_id: winnerId,
+      sets: isWo
+        ? []
+        : sets
+            .filter((s) => s.p1 > 0 || s.p2 > 0)
+            .map((s, i) => ({
+              set_number: i + 1,
+              player1_games: s.p1,
+              player2_games: s.p2,
+            })),
+      is_wo: isWo,
+    });
+
+    setSubmitting(false);
+    if (err) {
+      setError(err);
+    } else {
+      setSuccess(true);
+      setTimeout(onSuccess, 1500);
+    }
+  }
+
+  const winnerId = computeWinner();
+  const winnerName =
+    winnerId === match.player1_id
+      ? match.player1?.name
+      : match.player2?.name;
+
+  if (success) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-12 px-6">
+        <div className="w-16 h-16 rounded-full bg-lime-500/15 border border-lime-500/30 flex items-center justify-center">
+          <Trophy size={28} className="text-lime-500" />
+        </div>
+        <div className="text-center">
+          <p className="font-display font-bold text-white text-lg">Resultado registrado!</p>
+          {winnerName && (
+            <p className="text-white/40 text-sm mt-1">Vencedor: {winnerName}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-5 pb-8 pt-2">
+      {/* Match header */}
+      <div className="flex items-center gap-3 bg-surface-3 border border-white/[0.06] rounded-2xl p-4 mb-5">
+        <div className="flex-1 flex items-center gap-2 min-w-0">
+          <Avatar name={match.player1?.name ?? ""} src={match.player1?.avatar_url} size="sm" />
+          <span className="text-sm font-semibold text-white/80 truncate">
+            {match.player1?.name?.split(" ")[0]}
+          </span>
+        </div>
+        <span className="text-white/20 font-display font-bold text-xs px-2">VS</span>
+        <div className="flex-1 flex items-center gap-2 min-w-0 justify-end">
+          <span className="text-sm font-semibold text-white/80 truncate text-right">
+            {match.player2?.name?.split(" ")[0]}
+          </span>
+          <Avatar name={match.player2?.name ?? ""} src={match.player2?.avatar_url} size="sm" />
+        </div>
+      </div>
+
+      {!isParticipant ? (
+        <div className="bg-surface-3 border border-white/[0.06] rounded-xl px-4 py-6 text-center">
+          <p className="text-white/40 text-sm">
+            Apenas os participantes podem registrar o resultado desta partida.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* WO toggle */}
+          <div className="bg-surface-2 border border-white/[0.06] rounded-2xl p-4 mb-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold text-white/80">Walkover (WO)</p>
+                <p className="text-xs text-white/30 mt-0.5">Marque se houve ausência</p>
+              </div>
+              <button
+                onClick={() => {
+                  setIsWo(!isWo);
+                  setWoWinner(null);
+                }}
+                className={cn(
+                  "w-12 h-6 rounded-full transition-all relative shrink-0",
+                  isWo ? "bg-lime-500" : "bg-surface-4"
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute top-1 w-4 h-4 rounded-full bg-white shadow transition-all",
+                    isWo ? "left-7" : "left-1"
+                  )}
+                />
+              </button>
+            </div>
+
+            {isWo && (
+              <div className="mt-4">
+                <p className="text-xs text-white/30 mb-2">Quem recebeu o WO (vencedor)?</p>
+                <div className="flex gap-2">
+                  {(["p1", "p2"] as const).map((side) => {
+                    const p = side === "p1" ? match.player1 : match.player2;
+                    return (
+                      <button
+                        key={side}
+                        onClick={() => setWoWinner(side)}
+                        className={cn(
+                          "flex-1 flex items-center justify-center gap-2 p-3 rounded-xl border-2 transition-all",
+                          woWinner === side
+                            ? "border-lime-500/50 bg-lime-500/[0.06]"
+                            : "border-white/[0.06] bg-surface-3"
+                        )}
+                      >
+                        <Avatar name={p?.name ?? ""} size="xs" />
+                        <span className="text-xs font-bold text-white/70 truncate">
+                          {p?.name?.split(" ")[0]}
+                        </span>
+                        {woWinner === side && (
+                          <Check size={13} className="text-lime-500 shrink-0" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Sets */}
+          {!isWo && (
+            <div className="bg-surface-2 border border-white/[0.06] rounded-2xl p-4 mb-3">
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-[10px] font-display font-bold uppercase tracking-widest text-white/30">
+                  Placar dos Sets
+                </p>
+                {sets.length < 3 && (
+                  <button
+                    onClick={() => setSets((p) => [...p, { p1: 0, p2: 0 }])}
+                    className="text-xs text-lime-500/70 font-bold flex items-center gap-1 hover:text-lime-500 transition-colors"
+                  >
+                    <Plus size={12} /> {sets.length + 1}º Set
+                  </button>
+                )}
+              </div>
+
+              <div className="space-y-3">
+                {sets.map((set, idx) => (
+                  <div key={idx}>
+                    <div className="flex items-center justify-between mb-1.5">
+                      <span className="text-xs font-bold text-white/30">{idx + 1}º Set</span>
+                      {sets.length > 1 && (
+                        <button
+                          onClick={() => setSets((p) => p.filter((_, i) => i !== idx))}
+                          className="text-[10px] text-white/25 font-medium hover:text-white/50 transition-colors"
+                        >
+                          remover
+                        </button>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 bg-surface-3 border border-white/[0.04] rounded-xl p-3">
+                      <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                        <Avatar name={match.player1?.name ?? ""} size="xs" />
+                        <span className="text-xs font-semibold text-white/50 truncate">
+                          {match.player1?.name?.split(" ")[0]}
+                        </span>
+                      </div>
+                      <ScoreInput value={set.p1} onChange={(v) => updateSet(idx, "p1", v)} />
+                      <span className="text-white/15 font-black text-sm">–</span>
+                      <ScoreInput value={set.p2} onChange={(v) => updateSet(idx, "p2", v)} />
+                      <div className="flex items-center gap-1.5 flex-1 min-w-0 justify-end">
+                        <span className="text-xs font-semibold text-white/50 truncate text-right">
+                          {match.player2?.name?.split(" ")[0]}
+                        </span>
+                        <Avatar name={match.player2?.name ?? ""} size="xs" />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {winnerId && (
+                <div className="mt-4 bg-lime-500/[0.08] border border-lime-500/25 rounded-xl p-3 text-center">
+                  <p className="text-[10px] text-white/35 uppercase tracking-wider">Vencedor</p>
+                  <p className="text-sm font-display font-bold text-lime-400 mt-0.5">{winnerName}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 mb-3">
+              <p className="text-red-400 text-sm text-center">{error}</p>
+            </div>
+          )}
+
+          <Button
+            fullWidth
+            size="lg"
+            onClick={handleSubmit}
+            disabled={
+              submitting ||
+              (!isWo && !winnerId) ||
+              (isWo && !woWinner)
+            }
+            className="font-display font-bold tracking-wide"
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={16} className="animate-spin" /> Salvando...
+              </>
+            ) : (
+              "Confirmar e Encerrar Partida"
+            )}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/submitMatchResult.ts
+++ b/src/lib/actions/submitMatchResult.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+export interface SetScoreInput {
+  set_number: number;
+  player1_games: number;
+  player2_games: number;
+}
+
+export interface SubmitMatchResultInput {
+  match_id: string;
+  winner_id: string;
+  sets: SetScoreInput[];
+  is_wo: boolean;
+}
+
+export async function submitMatchResultAction(
+  input: SubmitMatchResultInput
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Sessão expirada. Faça login novamente." };
+
+  const { data: me } = await supabase
+    .from("players")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (!me) return { error: "Jogador não encontrado." };
+
+  const { data: match } = await supabase
+    .from("matches")
+    .select("id, player1_id, player2_id, status")
+    .eq("id", input.match_id)
+    .single();
+
+  if (!match) return { error: "Partida não encontrada." };
+  if (match.status === "completed" || match.status === "wo") {
+    return { error: "Esta partida já foi encerrada." };
+  }
+  if (match.player1_id !== me.id && match.player2_id !== me.id) {
+    return { error: "Você não tem permissão para registrar resultado desta partida." };
+  }
+
+  const { error: matchError } = await supabase
+    .from("matches")
+    .update({
+      winner_id: input.winner_id,
+      status: input.is_wo ? "wo" : "completed",
+    })
+    .eq("id", input.match_id);
+
+  if (matchError) return { error: matchError.message };
+
+  if (!input.is_wo && input.sets.length > 0) {
+    const { error: setsError } = await supabase
+      .from("match_sets")
+      .insert(input.sets.map((s) => ({ ...s, match_id: input.match_id })));
+    if (setsError) return { error: setsError.message };
+  }
+
+  return { error: null };
+}


### PR DESCRIPTION
## Resumo

- Novo componente `MatchResultPanel` para registrar placar diretamente no calendário, sem sair da página
- Nova server action `submitMatchResult` com validação de participante, status e sessão
- `CalendarioClient` atualizado: partidas agendadas do usuário exibem tag **"Registrar"** e abrem modal inline ao clicar
- Ao confirmar o resultado, a página é revalidada e o ranking e perfil do jogador refletem imediatamente

## Fluxo

1. Usuário acessa o Calendário
2. Partidas agendadas onde ele é participante mostram o botão **"Registrar"**
3. Ao clicar, abre um modal com o placar por set (ou opção WO)
4. Confirma → partida encerrada no banco → ranking e perfil atualizados automaticamente

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4o3xVkrGtwG2x5Ve3j37w)_