### PR TITLE
fix: remover prop onClose do uso do MatchResultPanel no CalendarioClient

### DIFF
--- a/src/app/(app)/calendario/CalendarioClient.tsx
+++ b/src/app/(app)/calendario/CalendarioClient.tsx
@@ -566,7 +566,6 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
               <MatchResultPanel
                 match={resultMatch}
                 currentPlayerId={currentPlayer?.id ?? ""}
-                onClose={() => setResultMatch(null)}
                 onSuccess={() => {
                   setResultMatch(null);
                   router.refresh();


### PR DESCRIPTION
Remove a prop `onClose` que foi passada para o `MatchResultPanel` no `CalendarioClient`, mas que já não existe na interface do componente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4o3xVkrGtwG2x5Ve3j37w)_