### PR TITLE
feat: corrigir delete e adicionar edição de resultado de partida

### DIFF
--- a/src/app/(app)/calendario/CalendarioClient.tsx
+++ b/src/app/(app)/calendario/CalendarioClient.tsx
@@ -15,7 +15,7 @@ import {
 import { ptBR } from "date-fns/locale";
 import {
   ChevronLeft, ChevronRight, Plus, X, Search,
-  Clock, MapPin, Check, Loader2, ClipboardList, Trash2, AlertTriangle,
+  Clock, MapPin, Check, Loader2, ClipboardList, Trash2, AlertTriangle, Pencil,
 } from "lucide-react";
 import { scheduleMatchAction } from "@/lib/actions/scheduleMatch";
 import { deleteMatchAction } from "@/lib/actions/deleteMatch";
@@ -79,6 +79,9 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
 
   // Result modal state
   const [resultMatch, setResultMatch] = useState<Match | null>(null);
+
+  // Edit result modal state
+  const [editMatch, setEditMatch] = useState<Match | null>(null);
 
   // Delete confirm state
   const [deleteMatch, setDeleteMatch] = useState<Match | null>(null);
@@ -181,6 +184,10 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
 
   function canDelete(match: Match): boolean {
     return isMyMatch(match) && (match.status === "scheduled" || match.status === "pending_result");
+  }
+
+  function canEdit(match: Match): boolean {
+    return isMyMatch(match) && (match.status === "completed" || match.status === "wo");
   }
 
   async function handleDelete() {
@@ -400,6 +407,14 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
                           Registrar
                         </span>
                       )}
+                      {canEdit(m) && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); setEditMatch(m); }}
+                          className="w-7 h-7 flex items-center justify-center rounded-lg text-white/25 hover:text-blue-400 hover:bg-blue-500/10 transition-colors"
+                        >
+                          <Pencil size={13} />
+                        </button>
+                      )}
                       {canDelete(m) && (
                         <button
                           onClick={(e) => { e.stopPropagation(); setDeleteError(null); setDeleteMatch(m); }}
@@ -608,6 +623,48 @@ export function CalendarioClient({ allMatches, allPlayers, currentPlayer }: Prop
           </div>
         </div>
       )}
+      {/* Edit result modal */}
+      {editMatch && (
+        <div className="fixed inset-0 z-50 flex flex-col justify-end">
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={() => setEditMatch(null)}
+          />
+          <div className="relative bg-surface-2 border-t border-white/[0.08] rounded-t-3xl max-h-[90vh] flex flex-col animate-slide-up">
+            <div className="flex justify-center pt-3 pb-1">
+              <div className="w-10 h-1 rounded-full bg-white/[0.12]" />
+            </div>
+            <div className="flex items-center justify-between px-5 py-3 border-b border-white/[0.06]">
+              <div>
+                <h2 className="font-display font-bold text-base text-white">Editar Resultado</h2>
+                {editMatch.scheduled_at && (
+                  <p className="text-[11px] text-white/30 capitalize mt-0.5">
+                    {format(new Date(editMatch.scheduled_at), "EEEE, d 'de' MMMM · HH:mm", { locale: ptBR })}
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => setEditMatch(null)}
+                className="w-8 h-8 flex items-center justify-center rounded-full bg-surface-3 text-white/40 hover:text-white hover:bg-surface-4 transition-colors"
+              >
+                <X size={15} />
+              </button>
+            </div>
+            <div className="overflow-y-auto flex-1">
+              <MatchResultPanel
+                match={editMatch}
+                currentPlayerId={currentPlayer?.id ?? ""}
+                mode="edit"
+                onSuccess={() => {
+                  setEditMatch(null);
+                  router.refresh();
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Delete confirmation modal */}
       {deleteMatch && (
         <div className="fixed inset-0 z-50 flex flex-col justify-end">

--- a/src/components/panels/MatchResultPanel.tsx
+++ b/src/components/panels/MatchResultPanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Minus, Check, Loader2, Trophy } from "lucide-react";
+import { Plus, Minus, Check, Loader2, Trophy, Pencil } from "lucide-react";
 import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { cn } from "@/utils/cn";
 import { submitMatchResultAction } from "@/lib/actions/submitMatchResult";
+import { editMatchResultAction } from "@/lib/actions/editMatchResult";
 import type { Match } from "@/types";
 
 interface SetScore {
@@ -46,13 +47,45 @@ function ScoreInput({
 interface Props {
   match: Match;
   currentPlayerId: string;
+  mode?: "register" | "edit";
   onSuccess: () => void;
 }
 
-export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
-  const [sets, setSets] = useState<SetScore[]>([{ p1: 0, p2: 0 }]);
-  const [isWo, setIsWo] = useState(false);
-  const [woWinner, setWoWinner] = useState<"p1" | "p2" | null>(null);
+function getInitialSets(match: Match, mode: "register" | "edit"): SetScore[] {
+  if (mode === "edit" && match.sets.length > 0) {
+    return match.sets
+      .slice()
+      .sort((a, b) => a.set_number - b.set_number)
+      .map((s) => ({ p1: s.player1_games, p2: s.player2_games }));
+  }
+  return [{ p1: 0, p2: 0 }];
+}
+
+function getInitialWo(match: Match, mode: "register" | "edit"): boolean {
+  return mode === "edit" && match.status === "wo";
+}
+
+function getInitialWoWinner(
+  match: Match,
+  mode: "register" | "edit"
+): "p1" | "p2" | null {
+  if (mode !== "edit" || match.status !== "wo" || !match.winner_id) return null;
+  return match.winner_id === match.player1_id ? "p1" : "p2";
+}
+
+export function MatchResultPanel({
+  match,
+  currentPlayerId,
+  mode = "register",
+  onSuccess,
+}: Props) {
+  const isEdit = mode === "edit";
+
+  const [sets, setSets] = useState<SetScore[]>(() => getInitialSets(match, mode));
+  const [isWo, setIsWo] = useState(() => getInitialWo(match, mode));
+  const [woWinner, setWoWinner] = useState<"p1" | "p2" | null>(() =>
+    getInitialWoWinner(match, mode)
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -83,7 +116,7 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
     setSubmitting(true);
     setError(null);
 
-    const { error: err } = await submitMatchResultAction({
+    const payload = {
       match_id: match.id,
       winner_id: winnerId,
       sets: isWo
@@ -96,7 +129,11 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
               player2_games: s.p2,
             })),
       is_wo: isWo,
-    });
+    };
+
+    const { error: err } = isEdit
+      ? await editMatchResultAction(payload)
+      : await submitMatchResultAction(payload);
 
     setSubmitting(false);
     if (err) {
@@ -109,18 +146,22 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
 
   const winnerId = computeWinner();
   const winnerName =
-    winnerId === match.player1_id
-      ? match.player1?.name
-      : match.player2?.name;
+    winnerId === match.player1_id ? match.player1?.name : match.player2?.name;
 
   if (success) {
     return (
       <div className="flex flex-col items-center gap-4 py-12 px-6">
         <div className="w-16 h-16 rounded-full bg-lime-500/15 border border-lime-500/30 flex items-center justify-center">
-          <Trophy size={28} className="text-lime-500" />
+          {isEdit ? (
+            <Pencil size={28} className="text-lime-500" />
+          ) : (
+            <Trophy size={28} className="text-lime-500" />
+          )}
         </div>
         <div className="text-center">
-          <p className="font-display font-bold text-white text-lg">Resultado registrado!</p>
+          <p className="font-display font-bold text-white text-lg">
+            {isEdit ? "Resultado atualizado!" : "Resultado registrado!"}
+          </p>
           {winnerName && (
             <p className="text-white/40 text-sm mt-1">Vencedor: {winnerName}</p>
           )}
@@ -151,7 +192,7 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
       {!isParticipant ? (
         <div className="bg-surface-3 border border-white/[0.06] rounded-xl px-4 py-6 text-center">
           <p className="text-white/40 text-sm">
-            Apenas os participantes podem registrar o resultado desta partida.
+            Apenas os participantes podem {isEdit ? "editar" : "registrar"} o resultado desta partida.
           </p>
         </div>
       ) : (
@@ -164,10 +205,7 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
                 <p className="text-xs text-white/30 mt-0.5">Marque se houve ausência</p>
               </div>
               <button
-                onClick={() => {
-                  setIsWo(!isWo);
-                  setWoWinner(null);
-                }}
+                onClick={() => { setIsWo(!isWo); setWoWinner(null); }}
                 className={cn(
                   "w-12 h-6 rounded-full transition-all relative shrink-0",
                   isWo ? "bg-lime-500" : "bg-surface-4"
@@ -285,17 +323,13 @@ export function MatchResultPanel({ match, currentPlayerId, onSuccess }: Props) {
             fullWidth
             size="lg"
             onClick={handleSubmit}
-            disabled={
-              submitting ||
-              (!isWo && !winnerId) ||
-              (isWo && !woWinner)
-            }
+            disabled={submitting || (!isWo && !winnerId) || (isWo && !woWinner)}
             className="font-display font-bold tracking-wide"
           >
             {submitting ? (
-              <>
-                <Loader2 size={16} className="animate-spin" /> Salvando...
-              </>
+              <><Loader2 size={16} className="animate-spin" /> Salvando...</>
+            ) : isEdit ? (
+              "Salvar Alterações"
             ) : (
               "Confirmar e Encerrar Partida"
             )}

--- a/src/lib/actions/editMatchResult.ts
+++ b/src/lib/actions/editMatchResult.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+export interface EditMatchResultInput {
+  match_id: string;
+  winner_id: string;
+  sets: { set_number: number; player1_games: number; player2_games: number }[];
+  is_wo: boolean;
+}
+
+export async function editMatchResultAction(
+  input: EditMatchResultInput
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Sessão expirada. Faça login novamente." };
+
+  const { data: me } = await supabase
+    .from("players")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (!me) return { error: "Jogador não encontrado." };
+
+  const { data: match } = await supabase
+    .from("matches")
+    .select("id, player1_id, player2_id, status")
+    .eq("id", input.match_id)
+    .single();
+
+  if (!match) return { error: "Partida não encontrada." };
+
+  const isParticipant = match.player1_id === me.id || match.player2_id === me.id;
+  if (!isParticipant) {
+    return { error: "Você não tem permissão para editar o resultado desta partida." };
+  }
+
+  if (match.status !== "completed" && match.status !== "wo") {
+    return { error: "Só é possível editar partidas já encerradas." };
+  }
+
+  // Delete existing sets
+  const { error: deleteError } = await supabase
+    .from("match_sets")
+    .delete()
+    .eq("match_id", input.match_id);
+
+  if (deleteError) return { error: deleteError.message };
+
+  // Update match
+  const { error: matchError } = await supabase
+    .from("matches")
+    .update({
+      winner_id: input.winner_id,
+      status: input.is_wo ? "wo" : "completed",
+    })
+    .eq("id", input.match_id);
+
+  if (matchError) return { error: matchError.message };
+
+  // Insert new sets
+  if (!input.is_wo && input.sets.length > 0) {
+    const { error: setsError } = await supabase
+      .from("match_sets")
+      .insert(input.sets.map((s) => ({ ...s, match_id: input.match_id })));
+    if (setsError) return { error: setsError.message };
+  }
+
+  return { error: null };
+}

--- a/src/lib/supabase/migrations.sql
+++ b/src/lib/supabase/migrations.sql
@@ -131,6 +131,26 @@ CREATE POLICY "Players insert match sets" ON match_sets
     )
   );
 
+-- Jogador exclui partidas agendadas das quais é participante (não encerradas)
+CREATE POLICY "Players delete own scheduled matches" ON matches
+  FOR DELETE USING (
+    auth.uid() IN (
+      SELECT p.user_id FROM players p
+      WHERE p.id = player1_id OR p.id = player2_id
+    )
+    AND status IN ('scheduled', 'pending_result')
+  );
+
+-- Jogador exclui sets das suas próprias partidas (para edição de resultado)
+CREATE POLICY "Players delete own match sets" ON match_sets
+  FOR DELETE USING (
+    auth.uid() IN (
+      SELECT p.user_id FROM players p
+      JOIN matches m ON (m.player1_id = p.id OR m.player2_id = p.id)
+      WHERE m.id = match_id
+    )
+  );
+
 COMMIT;
 
 -- ============================================================

--- a/src/lib/supabase/patch_001_delete_policies.sql
+++ b/src/lib/supabase/patch_001_delete_policies.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- Patch 001 — Políticas DELETE para jogadores
+-- Execute no SQL Editor do Supabase Dashboard
+-- ============================================================
+
+-- Permite que participantes excluam partidas ainda não encerradas
+CREATE POLICY "Players delete own scheduled matches" ON matches
+  FOR DELETE USING (
+    auth.uid() IN (
+      SELECT p.user_id FROM players p
+      WHERE p.id = player1_id OR p.id = player2_id
+    )
+    AND status IN ('scheduled', 'pending_result')
+  );
+
+-- Permite que participantes excluam os sets das suas próprias partidas
+-- (necessário para editar resultados já registrados)
+CREATE POLICY "Players delete own match sets" ON match_sets
+  FOR DELETE USING (
+    auth.uid() IN (
+      SELECT p.user_id FROM players p
+      JOIN matches m ON (m.player1_id = p.id OR m.player2_id = p.id)
+      WHERE m.id = match_id
+    )
+  );


### PR DESCRIPTION
## Resumo

### Correção do Delete
- `patch_001_delete_policies.sql` — políticas RLS que estavam faltando no Supabase
- Adiciona `Players delete own scheduled matches` (matches) e `Players delete own match sets` (match_sets)
- `migrations.sql` atualizado para novos ambientes

> ⚠️ **Ação necessária:** execute o arquivo `src/lib/supabase/patch_001_delete_policies.sql` no SQL Editor do Supabase Dashboard para habilitar o delete em produção.

### Edição de Resultado
- `editMatchResult.ts` — nova server action: deleta sets antigos e reinseriu os novos com o winner atualizado
- `MatchResultPanel` — agora aceita `mode="edit"` que pré-preenche o placar existente
- `CalendarioClient` — ícone de lápis ✏️ aparece nas partidas concluídas do usuário, abrindo modal de edição

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4o3xVkrGtwG2x5Ve3j37w)_