### PR TITLE
feat: ranking dividido por grupos com abas A/B/C/D

### DIFF
--- a/src/app/(app)/ranking/RankingClient.tsx
+++ b/src/app/(app)/ranking/RankingClient.tsx
@@ -1,13 +1,17 @@
 "use client";
 
+import { useState } from "react";
 import { Avatar } from "@/components/ui/Avatar";
 import { cn } from "@/utils/cn";
 import { Crown, Medal, TrendingUp } from "lucide-react";
-import type { Standing } from "@/types";
+import type { Standing, GroupLetter } from "@/types";
+
+const GROUPS: GroupLetter[] = ["A", "B", "C", "D"];
 
 interface Props {
-  globalRanking:   Standing[];
-  currentPlayerId: string | null;
+  allStandings:       Standing[];
+  currentPlayerId:    string | null;
+  currentPlayerGroup: GroupLetter | null;
 }
 
 function RankBadge({ position }: { position: number }) {
@@ -21,35 +25,67 @@ function RankBadge({ position }: { position: number }) {
   );
 }
 
-export function RankingClient({ globalRanking, currentPlayerId }: Props) {
-  const myStanding = globalRanking.find((s) => s.player.id === currentPlayerId);
-  const myPos      = globalRanking.findIndex((s) => s.player.id === currentPlayerId) + 1;
-  const top3       = globalRanking.slice(0, 3);
+export function RankingClient({ allStandings, currentPlayerId, currentPlayerGroup }: Props) {
+  const defaultGroup = currentPlayerGroup ?? "A";
+  const [activeGroup, setActiveGroup] = useState<GroupLetter>(defaultGroup);
+
+  const groupStandings = allStandings.filter((s) => s.group_letter === activeGroup);
+  const top3           = groupStandings.slice(0, 3);
+  const myStanding     = groupStandings.find((s) => s.player.id === currentPlayerId);
+  const myPos          = groupStandings.findIndex((s) => s.player.id === currentPlayerId) + 1;
 
   return (
     <div className="animate-slide-up">
-      {/* Hero — podium */}
+      {/* Header */}
       <div className="bg-green-900 px-4 pt-5 pb-8">
-        <h1 className="font-display font-bold text-white text-xl mb-6">Ranking Geral</h1>
+        <h1 className="font-display font-bold text-white text-xl mb-5">Ranking por Grupo</h1>
 
-        <div className="flex items-end justify-center gap-4">
-          {/* 2nd */}
-          {top3[1] && (
-            <div className="flex flex-col items-center gap-2 pb-1">
-              <Avatar name={top3[1].player.name} src={top3[1].player.avatar_url} size="md" />
-              <div className="text-center">
-                <p className="text-white/80 text-xs font-semibold leading-tight">
-                  {top3[1].player.name.split(" ")[0]}
-                </p>
-                <p className="text-white/35 text-[10px]">{top3[1].points} pts</p>
+        {/* Group tabs */}
+        <div className="flex gap-2 mb-7">
+          {GROUPS.map((g) => {
+            const hasPlayers = allStandings.some((s) => s.group_letter === g);
+            return (
+              <button
+                key={g}
+                onClick={() => setActiveGroup(g)}
+                disabled={!hasPlayers}
+                className={cn(
+                  "flex-1 py-2 rounded-xl font-display font-bold text-sm transition-all border",
+                  activeGroup === g
+                    ? "bg-lime-500 text-surface-0 border-lime-500 shadow-glow"
+                    : hasPlayers
+                    ? "bg-surface-0/30 text-white/60 border-white/[0.08] hover:border-white/20"
+                    : "bg-surface-0/10 text-white/20 border-white/[0.04] cursor-not-allowed"
+                )}
+              >
+                {g}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Podium */}
+        {top3.length > 0 ? (
+          <div className="flex items-end justify-center gap-4">
+            {/* 2nd */}
+            {top3[1] ? (
+              <div className="flex flex-col items-center gap-2 pb-1">
+                <Avatar name={top3[1].player.name} src={top3[1].player.avatar_url} size="md" />
+                <div className="text-center">
+                  <p className="text-white/80 text-xs font-semibold leading-tight">
+                    {top3[1].player.name.split(" ")[0]}
+                  </p>
+                  <p className="text-white/35 text-[10px]">{top3[1].points} pts</p>
+                </div>
+                <div className="w-14 bg-surface-3/80 border border-white/[0.07] rounded-t-lg h-12 flex items-center justify-center">
+                  <Medal size={16} className="text-white/40" />
+                </div>
               </div>
-              <div className="w-14 bg-surface-3/80 border border-white/[0.07] rounded-t-lg h-12 flex items-center justify-center">
-                <Medal size={16} className="text-white/40" />
-              </div>
-            </div>
-          )}
-          {/* 1st */}
-          {top3[0] && (
+            ) : (
+              <div className="w-14" />
+            )}
+
+            {/* 1st */}
             <div className="flex flex-col items-center gap-2 -mb-1">
               <Crown size={16} className="text-amber-400" />
               <Avatar
@@ -68,23 +104,30 @@ export function RankingClient({ globalRanking, currentPlayerId }: Props) {
                 <Crown size={18} className="text-lime-500" />
               </div>
             </div>
-          )}
-          {/* 3rd */}
-          {top3[2] && (
-            <div className="flex flex-col items-center gap-2 pb-1">
-              <Avatar name={top3[2].player.name} src={top3[2].player.avatar_url} size="md" />
-              <div className="text-center">
-                <p className="text-white/80 text-xs font-semibold leading-tight">
-                  {top3[2].player.name.split(" ")[0]}
-                </p>
-                <p className="text-white/35 text-[10px]">{top3[2].points} pts</p>
+
+            {/* 3rd */}
+            {top3[2] ? (
+              <div className="flex flex-col items-center gap-2 pb-1">
+                <Avatar name={top3[2].player.name} src={top3[2].player.avatar_url} size="md" />
+                <div className="text-center">
+                  <p className="text-white/80 text-xs font-semibold leading-tight">
+                    {top3[2].player.name.split(" ")[0]}
+                  </p>
+                  <p className="text-white/35 text-[10px]">{top3[2].points} pts</p>
+                </div>
+                <div className="w-14 bg-surface-3/80 border border-white/[0.07] rounded-t-lg h-8 flex items-center justify-center">
+                  <Medal size={14} className="text-amber-700/70" />
+                </div>
               </div>
-              <div className="w-14 bg-surface-3/80 border border-white/[0.07] rounded-t-lg h-8 flex items-center justify-center">
-                <Medal size={14} className="text-amber-700/70" />
-              </div>
-            </div>
-          )}
-        </div>
+            ) : (
+              <div className="w-14" />
+            )}
+          </div>
+        ) : (
+          <div className="text-center py-6">
+            <p className="text-white/25 text-sm">Nenhum jogador no grupo {activeGroup}</p>
+          </div>
+        )}
       </div>
 
       <div className="px-4 pt-3 pb-6 space-y-3">
@@ -94,14 +137,14 @@ export function RankingClient({ globalRanking, currentPlayerId }: Props) {
             <TrendingUp size={18} className="text-lime-500 shrink-0" />
             <div className="flex-1">
               <p className="text-white/40 text-[10px] font-semibold uppercase tracking-wider">
-                Sua posição
+                Sua posição · Grupo {activeGroup}
               </p>
               <p className="font-display font-bold text-white text-lg leading-tight">
-                {myPos}º de {globalRanking.length}
+                {myPos}º de {groupStandings.length}
               </p>
             </div>
             <div className="text-right">
-              <p className="font-display font-bold text-lime-500 text-2xl lime-glow leading-none">
+              <p className="font-display font-bold text-lime-500 text-2xl leading-none">
                 {myStanding.points}
               </p>
               <p className="text-white/25 text-[10px] font-semibold uppercase tracking-wide mt-0.5">
@@ -111,13 +154,13 @@ export function RankingClient({ globalRanking, currentPlayerId }: Props) {
           </div>
         )}
 
-        {/* Full list */}
+        {/* Standings table */}
         <div className="bg-surface-2 rounded-2xl border border-white/[0.06] overflow-hidden shadow-card">
           <div className="px-4 py-3 border-b border-white/[0.04] flex items-center justify-between">
             <span className="text-[10px] font-display font-bold uppercase tracking-widest text-white/35">
-              Classificação
+              Grupo {activeGroup}
             </span>
-            <span className="text-[10px] text-white/20">{globalRanking.length} jogadores</span>
+            <span className="text-[10px] text-white/20">{groupStandings.length} jogadores</span>
           </div>
 
           {/* Column headers */}
@@ -134,64 +177,64 @@ export function RankingClient({ globalRanking, currentPlayerId }: Props) {
             </div>
           </div>
 
-          {globalRanking.map((s, i) => {
-            const isCurrent = s.player.id === currentPlayerId;
-            const winRate   = s.matches_played > 0
-              ? Math.round((s.wins / s.matches_played) * 100)
-              : 0;
-            return (
-              <div
-                key={s.player.id}
-                className={cn(
-                  "flex items-center px-4 py-3 gap-3 border-b border-white/[0.03] last:border-0 transition-colors",
-                  isCurrent ? "bg-lime-500/[0.06]" : "hover:bg-white/[0.02]"
-                )}
-              >
-                <div className="w-5 flex justify-center shrink-0">
-                  <RankBadge position={i + 1} />
-                </div>
-                <Avatar
-                  name={s.player.name}
-                  src={s.player.avatar_url}
-                  size="sm"
-                  className={cn(isCurrent && "ring-2 ring-lime-500/50 ring-offset-1 ring-offset-surface-2")}
-                />
-                <div className="flex-1 min-w-0">
-                  <p className={cn(
-                    "text-sm font-semibold truncate",
-                    isCurrent ? "text-lime-400" : "text-white/80"
-                  )}>
-                    {s.player.name}
-                    {isCurrent && (
-                      <span className="ml-1.5 text-[9px] text-lime-500/70 font-bold uppercase tracking-wide">
-                        você
-                      </span>
-                    )}
-                  </p>
-                  <p className="text-[10px] text-white/25">
-                    Grupo {s.group_letter} · {winRate}% aprov.
-                  </p>
-                </div>
-                <div className="flex items-center gap-3 shrink-0">
-                  <div className="text-center w-6">
-                    <p className="text-sm font-display font-bold text-white/80">{s.points}</p>
-                  </div>
-                  <div className="text-center w-6">
-                    <p className="text-sm font-bold text-lime-500">{s.wins}</p>
-                  </div>
-                  <div className="text-center w-6">
-                    <p className="text-sm font-bold text-red-400/70">{s.losses}</p>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-
-          {globalRanking.length === 0 && (
+          {groupStandings.length === 0 ? (
             <div className="py-14 text-center">
               <p className="text-4xl mb-3">🎾</p>
-              <p className="text-white/25 text-sm">Nenhuma partida registrada ainda</p>
+              <p className="text-white/25 text-sm">Nenhuma partida registrada neste grupo</p>
             </div>
+          ) : (
+            groupStandings.map((s, i) => {
+              const isCurrent = s.player.id === currentPlayerId;
+              const winRate   = s.matches_played > 0
+                ? Math.round((s.wins / s.matches_played) * 100)
+                : 0;
+              return (
+                <div
+                  key={s.player.id}
+                  className={cn(
+                    "flex items-center px-4 py-3 gap-3 border-b border-white/[0.03] last:border-0 transition-colors",
+                    isCurrent ? "bg-lime-500/[0.06]" : "hover:bg-white/[0.02]"
+                  )}
+                >
+                  <div className="w-5 flex justify-center shrink-0">
+                    <RankBadge position={i + 1} />
+                  </div>
+                  <Avatar
+                    name={s.player.name}
+                    src={s.player.avatar_url}
+                    size="sm"
+                    className={cn(isCurrent && "ring-2 ring-lime-500/50 ring-offset-1 ring-offset-surface-2")}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className={cn(
+                      "text-sm font-semibold truncate",
+                      isCurrent ? "text-lime-400" : "text-white/80"
+                    )}>
+                      {s.player.name}
+                      {isCurrent && (
+                        <span className="ml-1.5 text-[9px] text-lime-500/70 font-bold uppercase tracking-wide">
+                          você
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-[10px] text-white/25">
+                      {s.matches_played} partida{s.matches_played !== 1 ? "s" : ""} · {winRate}% aprov.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <div className="text-center w-6">
+                      <p className="text-sm font-display font-bold text-white/80">{s.points}</p>
+                    </div>
+                    <div className="text-center w-6">
+                      <p className="text-sm font-bold text-lime-500">{s.wins}</p>
+                    </div>
+                    <div className="text-center w-6">
+                      <p className="text-sm font-bold text-red-400/70">{s.losses}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
           )}
         </div>
       </div>

--- a/src/app/(app)/ranking/page.tsx
+++ b/src/app/(app)/ranking/page.tsx
@@ -5,7 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 export const metadata: Metadata = { title: "Ranking" };
 import { getPlayerByUserId, getAllPlayers } from "@/lib/queries/players";
 import { getAllMatches } from "@/lib/queries/matches";
-import { computeAllStandings, computeGlobalRanking } from "@/lib/queries/standings";
+import { computeAllStandings } from "@/lib/queries/standings";
 import { RankingClient } from "./RankingClient";
 
 export default async function RankingPage() {
@@ -20,12 +20,12 @@ export default async function RankingPage() {
   ]);
 
   const allStandings = computeAllStandings(allPlayers, allMatches);
-  const globalRanking = computeGlobalRanking(allStandings);
 
   return (
     <RankingClient
-      globalRanking={globalRanking}
+      allStandings={allStandings}
       currentPlayerId={currentPlayer?.id ?? null}
+      currentPlayerGroup={currentPlayer?.group_letter ?? null}
     />
   );
 }


### PR DESCRIPTION
## Resumo

- Ranking agora exibido por grupo com abas **A / B / C / D**
- Pódio (top 3) e tabela de classificação filtrados pelo grupo selecionado
- A aba abre automaticamente no grupo do jogador logado
- Card "Sua posição" reflete a posição dentro do grupo ativo
- `page.tsx` passa `allStandings` e `currentPlayerGroup` — sem mais `computeGlobalRanking`

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4o3xVkrGtwG2x5Ve3j37w)_