### PR TITLE
feat: reestruturar nav mobile com FAB central e animação de saída

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,62 +1,91 @@
 "use client";
 
+import { type ElementType } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Layers, Trophy, Users, User, Settings } from "lucide-react";
+import { Home, Layers, Trophy, User, Settings, Plus } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { useCurrentPlayer } from "@/lib/hooks/useCurrentPlayer";
+import { useContextPanel } from "./ContextPanelProvider";
 
-const baseNavItems = [
+const leftItems = [
   { href: "/dashboard", label: "Início",  Icon: Home },
   { href: "/calendario", label: "Jogos",  Icon: Layers },
-  { href: "/ranking",   label: "Ranking", Icon: Trophy },
-  { href: "/grupos",    label: "Grupos",  Icon: Users },
-  { href: "/perfil",    label: "Perfil",  Icon: User },
 ];
 
-const adminNavItem = { href: "/admin", label: "Admin", Icon: Settings };
+const rightItems = [
+  { href: "/ranking", label: "Ranking", Icon: Trophy },
+  { href: "/perfil",  label: "Perfil",  Icon: User },
+];
+
+const adminItem = { href: "/admin", label: "Admin", Icon: Settings };
 
 export function BottomNav() {
-  const pathname = usePathname();
-  const player   = useCurrentPlayer();
-  const navItems = player?.is_admin ? [...baseNavItems, adminNavItem] : baseNavItems;
+  const pathname      = usePathname();
+  const player        = useCurrentPlayer();
+  const { openPanel, panel } = useContextPanel();
+
+  const isPanelOpen = panel.type !== null;
+
+  const allRight = player?.is_admin
+    ? [...rightItems, adminItem]
+    : rightItems;
+
+  function NavLink({ href, label, Icon }: { href: string; label: string; Icon: ElementType }) {
+    const active = pathname === href || pathname.startsWith(href + "/");
+    return (
+      <Link
+        href={href}
+        className="flex flex-col items-center justify-center gap-1 flex-1 py-2 rounded-xl transition-all duration-200"
+      >
+        <Icon
+          size={20}
+          strokeWidth={active ? 2.5 : 1.8}
+          className={cn(
+            "transition-colors duration-200",
+            active ? "text-lime-500" : "text-white/35"
+          )}
+        />
+        <span className={cn(
+          "text-[9px] font-semibold tracking-wide uppercase transition-colors duration-200",
+          active ? "text-lime-500" : "text-white/30"
+        )}>
+          {label}
+        </span>
+      </Link>
+    );
+  }
 
   return (
-    <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 flex justify-center pb-5 px-4 pointer-events-none">
-      <nav className="pointer-events-auto flex items-center h-[62px] bg-surface-3/95 backdrop-blur-2xl shadow-nav rounded-[22px] border border-white/[0.09] px-1.5 gap-0.5">
-        {navItems.map(({ href, label, Icon }) => {
-          const active = pathname === href || pathname.startsWith(href + "/");
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={cn(
-                "flex flex-col items-center justify-center gap-1 px-3.5 py-2 rounded-xl transition-all duration-200",
-                active
-                  ? "bg-white/[0.07]"
-                  : "hover:bg-white/[0.04]"
-              )}
+    <div
+      className={cn(
+        "md:hidden fixed bottom-0 left-0 right-0 z-50 transition-transform duration-300 ease-in-out",
+        isPanelOpen ? "translate-y-full" : "translate-y-0"
+      )}
+    >
+      <div className="flex justify-center pb-5 px-4">
+        <nav className="flex items-center w-full max-w-sm h-[62px] bg-surface-3/95 backdrop-blur-2xl shadow-nav rounded-[22px] border border-white/[0.09] px-2">
+          {/* Left items */}
+          {leftItems.map((item) => (
+            <NavLink key={item.href} {...item} />
+          ))}
+
+          {/* Center FAB */}
+          <div className="flex items-center justify-center flex-shrink-0 px-2">
+            <button
+              onClick={() => openPanel("schedule-match")}
+              className="w-12 h-12 -mt-5 rounded-2xl bg-lime-500 hover:bg-lime-400 active:scale-90 transition-all duration-150 flex items-center justify-center shadow-glow border-2 border-surface-3"
             >
-              <Icon
-                size={20}
-                strokeWidth={active ? 2.5 : 1.8}
-                className={cn(
-                  "transition-colors duration-200",
-                  active ? "text-lime-500" : "text-white/30"
-                )}
-              />
-              <span
-                className={cn(
-                  "text-[9px] font-semibold tracking-wide uppercase transition-colors duration-200",
-                  active ? "text-lime-500" : "text-white/30"
-                )}
-              >
-                {label}
-              </span>
-            </Link>
-          );
-        })}
-      </nav>
+              <Plus size={22} className="text-surface-0" strokeWidth={2.5} />
+            </button>
+          </div>
+
+          {/* Right items */}
+          {allRight.map((item) => (
+            <NavLink key={item.href} {...item} />
+          ))}
+        </nav>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/ContextPanel.tsx
+++ b/src/components/layout/ContextPanel.tsx
@@ -14,13 +14,12 @@ export function ContextPanel() {
   const { panel, closePanel } = useContextPanel();
   const isOpen = panel.type !== null;
 
-  // Keep content mounted during the close animation (300ms)
   const [displayType, setDisplayType] = useState<PanelType | null>(panel.type);
   useEffect(() => {
     if (panel.type) {
       setDisplayType(panel.type);
     } else {
-      const t = setTimeout(() => setDisplayType(null), 300);
+      const t = setTimeout(() => setDisplayType(null), 350);
       return () => clearTimeout(t);
     }
   }, [panel.type]);
@@ -32,19 +31,20 @@ export function ContextPanel() {
         aria-hidden
         onClick={closePanel}
         className={cn(
-          "fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm transition-opacity duration-300",
+          "fixed inset-0 z-[60] bg-black/65 backdrop-blur-sm transition-opacity duration-300",
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         )}
       />
 
-      {/* Panel */}
+      {/* Panel — slides up from the very bottom */}
       <div
         role="dialog"
         aria-modal={isOpen}
         className={cn(
-          "fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md z-[70]",
+          "fixed bottom-0 left-0 right-0 z-[70]",
+          "md:left-1/2 md:-translate-x-1/2 md:w-full md:max-w-md",
           "bg-surface-1 border border-white/[0.07] border-b-0 rounded-t-3xl",
-          "transition-transform duration-300 ease-out",
+          "transition-transform duration-350 ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform",
           isOpen ? "translate-y-0" : "translate-y-full pointer-events-none"
         )}
       >
@@ -67,7 +67,7 @@ export function ContextPanel() {
         </div>
 
         {/* Content */}
-        <div className="max-h-[78vh] overflow-y-auto overscroll-contain">
+        <div className="max-h-[78vh] overflow-y-auto overscroll-contain pb-safe">
           {displayType === "schedule-match" && (
             <ScheduleMatchPanel onClose={closePanel} />
           )}


### PR DESCRIPTION
## Resumo

### BottomNav reestruturado
- Layout com **FAB `+` central** para "Agendar Partida" em destaque
- 2 itens à esquerda (Início, Jogos) + 2 à direita (Ranking, Perfil)
- Quando o painel de agendamento abre, o nav desliza para fora da tela (`translate-y-full`) e volta suavemente ao fechar — sem sobreposição estática

### ContextPanel melhorado
- Curva de animação `cubic-bezier(0.32, 0.72, 0, 1)` para feel mais nativo
- `will-change: transform` para GPU acceleration
- `pb-safe` para respeitar a home bar do iPhone

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4o3xVkrGtwG2x5Ve3j37w)_